### PR TITLE
upgrade bootstrap@4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remember_the_pantry",
   "private": true,
   "dependencies": {
-    "bootstrap": "4",
+    "bootstrap": "^4.1.2",
     "jquery": "^3.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-bootstrap@4:
+bootstrap@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
 


### PR DESCRIPTION
こんなアラートが届いたので、bootstrapをアップデート

> yiworks,
> We found a potential security vulnerability in a repository for which you have been granted security alert access.
> 
> yiworks/remember-the-pantry
> 
> 
> Known moderate severity security vulnerability detected in bootstrap < 4.1.2defined in package.json.
> 
> package.json update suggested: bootstrap ~> 4.1.2.
> Always verify the validity and compatibility of suggestions with your codebase.
> 
> 